### PR TITLE
refactor Form render props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "react-bootstrap-validation",
+  "name": "react-bootstrap-validation-loicuv",
   "version": "0.1.7",
-  "description": "Form validation for react-bootstrap",
+  "description": "Form validation for react-bootstrap without default className on form element",
   "main": "./lib/index.js",
   "repository": {
     "type": "git",
@@ -25,7 +25,7 @@
   ],
   "author": "Ivan Reshetnikov <keenn2007@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/loicuv/react-bootstrap-validation",
+  "homepage": "https://github.com/heilhead/react-bootstrap-validation",
   "peerDependencies": {
     "react": ">=0.13"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "author": "Ivan Reshetnikov <keenn2007@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/heilhead/react-bootstrap-validation",
+  "homepage": "https://github.com/loicuv/react-bootstrap-validation",
   "peerDependencies": {
     "react": ">=0.13"
   },

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "./lib/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/heilhead/react-bootstrap-validation.git"
+    "url": "https://github.com/loicuv/react-bootstrap-validation.git"
   },
   "bugs": {
-    "url": "https://github.com/heilhead/react-bootstrap-validation/issues"
+    "url": "https://github.com/loicuv/react-bootstrap-validation/issues"
   },
   "directories": {
     "lib": "lib/"

--- a/src/Form.js
+++ b/src/Form.js
@@ -48,10 +48,9 @@ export default class Form extends InputContainer {
 
     render() {
         return (
-            <form ref="form"
-                  onSubmit={this._handleSubmit.bind(this)}
-                  action="#"
-                  className={this.props.className}>
+            <form {...this.props}
+                  ref="form"
+                  onSubmit={this._handleSubmit.bind(this)}>
                 {this._renderChildren(this.props.children)}
             </form>
         );

--- a/src/Form.js
+++ b/src/Form.js
@@ -315,7 +315,6 @@ Form.propTypes = {
 
 Form.defaultProps = {
     model          : {},
-    className      : 'form-horizontal',
     validationEvent: 'onChange',
     onInvalidSubmit: () => {}
 };


### PR DESCRIPTION
- Ability to pass form element attributes directly in `<Form>`.
- Remove default `form-horizontal` class on form element
