### PR TITLE
Limit react-bootstrap import to Input only

### DIFF
--- a/src/ValidatedInput.js
+++ b/src/ValidatedInput.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Input } from 'react-bootstrap';
+import Input from 'react-bootstrap/lib/Input';
 
 export default class ValidatedInput extends Input {
     constructor(props) {


### PR DESCRIPTION
This PR reduces the impact of importing react-bootstrap and should reduce final file size for both this library and programs using it.  See http://react-bootstrap.github.io/getting-started.html#commonjs
