### PR TITLE
Fix bug children is array of length 1

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -140,10 +140,8 @@ export default class Form extends InputContainer {
 
         let childrenCount = React.Children.count(children);
 
-        if (childrenCount === 1) {
-            return processChild(children);
-        } else if (childrenCount > 1) {
-            return React.Children.map(children, processChild);
+        if (childrenCount > 0) {
+            return ( Array.isArray(children) ? React.Children.map(children, processChild) : processChild(children) );
         }
     }
 


### PR DESCRIPTION
We always do data.map with data coming from backend, when the length of data is 1 (rare case), _renderChildren treat it as a element !! then it goes to React.cloneElement( array(element), {}, ....) which cause the render stop completely in our case.
