### PR TITLE
Allows to define action in forms

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -51,7 +51,7 @@ export default class Form extends InputContainer {
         return (
             <form ref="form"
                   onSubmit={this._handleSubmit.bind(this)}
-                  action="#"
+                  action={this.props.action}
                   className={this.props.className}>
                 {this._renderChildren(this.props.children)}
             </form>
@@ -326,6 +326,7 @@ export default class Form extends InputContainer {
 
 Form.propTypes = {
     className      : React.PropTypes.string,
+    action         : React.PropTypes.string,
     model          : React.PropTypes.object,
     onValidSubmit  : React.PropTypes.func.isRequired,
     onInvalidSubmit: React.PropTypes.func,
@@ -341,6 +342,7 @@ Form.propTypes = {
 };
 
 Form.defaultProps = {
+    action         : '#',
     model          : {},
     validationEvent: 'onChange',
     onInvalidSubmit: () => {}


### PR DESCRIPTION
The action of the form is now available as a prop. By default the action leads to `#`, but can now be customizable.
